### PR TITLE
Hiding LeadStatusChange trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ## 1.0.14
 
-* Added trigger `Lead Status Change`
 * Support for 429 responses from Public API (Rate Limiting) - App will not break while trying to parse response
 
 ## 1.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.17
+
+* Fixing internal warnings related to output types
+
 ## 1.0.16
 
 * Bumping other dependencies

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zendesk-sell-for-zapier",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Zendesk Sell App in Zapier",
   "repository": "git@github.com:zendesk/zendesk-sell-for-zapier.git",
   "homepage": "https://www.zendesk.com/sell/",

--- a/src/common/outputFields.ts
+++ b/src/common/outputFields.ts
@@ -91,8 +91,8 @@ export const personalOutputFields: OutputField[] = [
 
 export const tagsOutputFields: OutputField[] = [
   {
-    key: 'tags',
-    label: 'Tags'
+    key: 'tags[]',
+    label: 'Tags',
   }
 ]
 

--- a/src/common/outputFields.ts
+++ b/src/common/outputFields.ts
@@ -3,11 +3,13 @@ import {OutputField} from '../types'
 export const deduplicationOutputFields: OutputField[] = [
   {
     key: 'entity_original_id',
-    label: 'ID'
+    label: 'ID',
+    type: 'integer'
   },
   {
     key: 'id',
-    label: 'Zapier Deduplication ID'
+    label: 'Zapier Deduplication ID',
+    type: 'string',
   }
 ]
 
@@ -15,10 +17,12 @@ export const creatorOwnerOutputFields: OutputField[] = [
   {
     key: 'owner_id',
     label: 'Owner',
+    type: 'integer'
   },
   {
     key: 'creator_id',
-    label: 'Creator'
+    label: 'Creator',
+    type: 'integer'
   }
 ]
 
@@ -26,50 +30,62 @@ export const personalOutputFields: OutputField[] = [
   {
     key: 'title',
     label: 'Title',
+    type: 'string'
   },
   {
     key: 'description',
-    label: 'Description'
+    label: 'Description',
+    type: 'string'
   },
   {
     key: 'industry',
-    label: 'Industry'
+    label: 'Industry',
+    type: 'string'
   },
   {
     key: 'website',
-    label: 'Website'
+    label: 'Website',
+    type: 'string'
   },
   {
     key: 'email',
-    label: 'Email'
+    label: 'Email',
+    type: 'string'
   },
   {
     key: 'phone',
-    label: 'Phone'
+    label: 'Phone',
+    type: 'string'
   },
   {
     key: 'mobile',
-    label: 'Mobile'
+    label: 'Mobile',
+    type: 'string'
   },
   {
     key: 'fax',
-    label: 'Fax'
+    label: 'Fax',
+    type: 'string'
   },
   {
     key: 'twitter',
-    label: 'Twitter'
+    label: 'Twitter',
+    type: 'string'
   },
   {
     key: 'facebook',
-    label: 'Facebook'
+    label: 'Facebook',
+    type: 'string'
   },
   {
     key: 'linkedin',
-    label: 'LinkedIn'
+    label: 'LinkedIn',
+    type: 'string'
   },
   {
     key: 'skype',
-    label: 'Skype'
+    label: 'Skype',
+    type: 'string'
   }
 ]
 
@@ -84,21 +100,26 @@ export const addressOutputFields: OutputField[] = [
   {
     key: 'address__line1',
     label: 'Street',
+    type: 'string'
   },
   {
     key: 'address__city',
     label: 'City',
+    type: 'string'
   },
   {
     key: 'address__postal_code',
     label: 'Zip/Post Code',
+    type: 'string'
   },
   {
     key: 'address__state',
     label: 'State',
+    type: 'string'
   },
   {
     key: 'address__country',
     label: 'Country',
+    type: 'string'
   }
 ]

--- a/src/contact/contact.resource.ts
+++ b/src/contact/contact.resource.ts
@@ -47,6 +47,7 @@ const ContactResource = {
     {
       key: 'id',
       label: 'ID',
+      type: 'integer',
     },
     ...commonContactOutputFields
   ]

--- a/src/contact/fields/contactOutputFields.ts
+++ b/src/contact/fields/contactOutputFields.ts
@@ -12,22 +12,27 @@ export const commonContactOutputFields = [
   {
     key: 'name',
     label: 'Name',
+    type: 'string',
   },
   {
     key: 'first_name',
     label: 'First Name',
+    type: 'string',
   },
   {
     key: 'last_name',
     label: 'Last Name',
+    type: 'string',
   },
   {
     key: 'contact_id',
-    label: 'Organisation'
+    label: 'Organisation',
+    type: 'integer',
   },
   {
     key: 'parent_organization_id',
-    label: 'Parent Company'
+    label: 'Parent Company',
+    type: 'integer',
   },
   ...personalOutputFields,
   ...addressOutputFields,

--- a/src/contact/updatedContact.trigger.ts
+++ b/src/contact/updatedContact.trigger.ts
@@ -1,7 +1,7 @@
 import {Bundle, ZObject} from 'zapier-platform-core'
 import {fetchContactsTrigger} from './common'
 import {ZapierItem} from '../types'
-import {findAndRemapOnlyUpdatedItems} from '../utils/deduplication'
+import {findAndRemapOnlyUpdatedItems, sampleWithDeduplicationId} from '../utils/deduplication'
 import {deduplicationOutputFields} from '../common/outputFields'
 import {commonContactOutputFields} from './fields/contactOutputFields'
 import {contactTriggers} from './keys'
@@ -31,7 +31,7 @@ const UpdatedContactTrigger: ZapierItem = {
 
   operation: {
     // Resource cannot be used here, because of different output fields (deduplication)
-    sample: contactSample,
+    sample: sampleWithDeduplicationId(contactSample),
     inputFields: [
       {
         key: 'is_organization',

--- a/src/deal/deal.resource.ts
+++ b/src/deal/deal.resource.ts
@@ -37,6 +37,7 @@ const DealResource = {
     {
       key: 'id',
       label: 'ID',
+      type: 'integer',
     },
     ...dealCommonOutputFields
   ]

--- a/src/deal/dealStageChange.trigger.ts
+++ b/src/deal/dealStageChange.trigger.ts
@@ -4,7 +4,7 @@ import DealResource, {dealSample} from './deal.resource'
 import {ZapierItem} from '../types'
 import {deduplicationOutputFields} from '../common/outputFields'
 import {dealCommonOutputFields} from './fields/dealOutputFields'
-import {findAndRemapOnlyStageUpdatedItems} from '../utils/deduplication'
+import {findAndRemapOnlyStageUpdatedItems, sampleWithDeduplicationId} from '../utils/deduplication'
 import {dealTriggers, pipelineTriggers, stageTriggers} from './keys'
 
 const stageChangeAtField = 'last_stage_change_at'
@@ -30,7 +30,7 @@ export const DealStageChangeTrigger: ZapierItem = {
   },
   operation: {
     // Resource cannot be used here, because of different output fields (deduplication)
-    sample: dealSample,
+    sample: sampleWithDeduplicationId(dealSample),
     inputFields: [
       {
         key: 'pipeline_id',

--- a/src/deal/fields/dealOutputFields.ts
+++ b/src/deal/fields/dealOutputFields.ts
@@ -6,46 +6,57 @@ export const dealCommonOutputFields = [
   {
     key: 'owner_id',
     label: 'Owner',
+    type: 'integer',
   },
   {
     key: 'name',
     label: 'Name',
+    type: 'string',
   },
   {
     key: 'value',
-    label: 'Value'
+    label: 'Value',
+    type: 'string',
   },
   {
     key: 'currency',
     label: 'Currency',
+    type: 'string',
   },
   {
     key: 'hot',
     label: 'Hot',
+    type: 'boolean',
   },
   {
     key: 'stage_id',
     label: 'Stage',
+    type: 'integer',
   },
   {
     key: 'source_id',
-    label: 'Source'
+    label: 'Source',
+    type: 'integer',
   },
   {
     key: 'loss_reason_id',
-    label: 'Loss Reason'
+    label: 'Loss Reason',
+    type: 'integer',
   },
   {
     key: 'dropbox_email',
-    label: 'Dropbox Email'
+    label: 'Dropbox Email',
+    type: 'string',
   },
   {
     key: 'contact_id',
-    label: 'Primary Contact'
+    label: 'Primary Contact',
+    type: 'integer',
   },
   {
     key: 'organization_id',
-    label: 'Company'
+    label: 'Company',
+    type: 'integer',
   },
   ...tagsOutputFields,
   customFieldOutputFields(EntityType.Deal)

--- a/src/deal/updatedDeal.trigger.ts
+++ b/src/deal/updatedDeal.trigger.ts
@@ -1,7 +1,7 @@
 import {Bundle, ZObject} from 'zapier-platform-core'
 import {fetchDealsTrigger} from './common'
 import {ZapierItem} from '../types'
-import {findAndRemapOnlyUpdatedItems} from '../utils/deduplication'
+import {findAndRemapOnlyUpdatedItems, sampleWithDeduplicationId} from '../utils/deduplication'
 import {deduplicationOutputFields} from '../common/outputFields'
 import {dealCommonOutputFields} from './fields/dealOutputFields'
 import {dealTriggers} from './keys'
@@ -25,7 +25,7 @@ const UpdatedDealTrigger: ZapierItem = {
   },
   operation: {
     // Resource cannot be used here, because of different output fields (deduplication)
-    sample: dealSample,
+    sample: sampleWithDeduplicationId(dealSample),
     outputFields: [
       ...deduplicationOutputFields,
       ...dealCommonOutputFields

--- a/src/lead/fields/leadOutputFields.ts
+++ b/src/lead/fields/leadOutputFields.ts
@@ -12,28 +12,34 @@ export const commonLeadOutputFields = [
   {
     key: 'first_name',
     label: 'First Name',
+    type: 'string',
   },
   {
     key: 'last_name',
     label: 'Last Name',
+    type: 'string',
   },
   {
     key: 'organization_name',
     label: 'Company Name',
+    type: 'string',
   },
   {
     key: 'status',
     label: 'Status',
+    type: 'string',
   },
   {
     key: 'source_id',
     label: 'Source',
+    type: 'integer',
   },
   ...personalOutputFields,
   ...tagsOutputFields,
   {
     key: 'unqualified_reason_id',
-    label: 'Unqualified Reason'
+    label: 'Unqualified Reason',
+    type: 'string',
   },
   ...addressOutputFields,
   customFieldOutputFields(EntityType.Lead)

--- a/src/lead/lead.resource.ts
+++ b/src/lead/lead.resource.ts
@@ -41,6 +41,7 @@ const LeadResource = {
     {
       key: 'id',
       label: 'ID',
+      type: 'integer'
     },
     ...commonLeadOutputFields
   ]

--- a/src/lead/leadStatusChange.trigger.ts
+++ b/src/lead/leadStatusChange.trigger.ts
@@ -26,6 +26,10 @@ export const LeadStatusChangeTrigger: ZapierItem = {
     label: 'Lead Enters New Status',
     description: 'Triggers when a lead has change status',
     important: false,
+    // TODO Unfortunately, this implementation causes false-positives and reacts also
+    //      upon lead creation. We cannot build reliable solution for update using DeduplicationId
+    //      build from LeadId + StatusValue
+    hidden: true
   },
   operation: {
     sample: leadSample,

--- a/src/lead/updatedLead.trigger.ts
+++ b/src/lead/updatedLead.trigger.ts
@@ -1,7 +1,7 @@
 import {Bundle, ZObject} from 'zapier-platform-core'
 import {fetchLeadsTrigger} from './common'
 import {ZapierItem} from '../types'
-import {findAndRemapOnlyUpdatedItems} from '../utils/deduplication'
+import {findAndRemapOnlyUpdatedItems, sampleWithDeduplicationId} from '../utils/deduplication'
 import {deduplicationOutputFields} from '../common/outputFields'
 import {commonLeadOutputFields} from './fields/leadOutputFields'
 import {leadTriggers} from './keys'
@@ -25,7 +25,7 @@ const UpdatedLeadTrigger: ZapierItem = {
   },
   operation: {
     // Resource cannot be used here, because of different output fields (deduplication)
-    sample: leadSample,
+    sample: sampleWithDeduplicationId(leadSample),
     outputFields: [
       ...deduplicationOutputFields,
       ...commonLeadOutputFields

--- a/src/notesTasks/notes/note.resouce.ts
+++ b/src/notesTasks/notes/note.resouce.ts
@@ -13,23 +13,28 @@ const NoteResource = {
   outputFields: [
     {
       key: 'id',
-      label: 'Note ID'
+      label: 'Note ID',
+      type: 'integer',
     },
     {
       key: 'content',
-      label: 'Content'
+      label: 'Content',
+      type: 'text',
     },
     {
       key: 'creator_id',
-      label: 'Creator'
+      label: 'Creator',
+      type: 'integer',
     },
     {
       key: 'resource_type',
       label: 'Resource Type',
+      type: 'string',
     },
     {
       key: 'resource_id',
-      label: 'Resource Id'
+      label: 'Resource Id',
+      type: 'integer',
     }
   ]
 }

--- a/src/notesTasks/tasks/task.resource.ts
+++ b/src/notesTasks/tasks/task.resource.ts
@@ -19,27 +19,33 @@ const TaskResource = {
   outputFields: [
     {
       key: 'id',
-      label: 'Task ID'
+      label: 'Task ID',
+      type: 'integer',
     },
     {
       key: 'content',
-      label: 'Content'
+      label: 'Content',
+      type: 'text',
     },
     {
       key: 'creator_id',
-      label: 'Creator'
+      label: 'Creator',
+      type: 'integer',
     },
     {
       key: 'owner_id',
-      label: 'Owner'
+      label: 'Owner',
+      type: 'integer',
     },
     {
       key: 'resource_type',
       label: 'Resource Type',
+      type: 'string',
     },
     {
       key: 'resource_id',
-      label: 'Resource Id'
+      label: 'Resource Id',
+      type: 'integer',
     },
     {
       key: 'due_date',
@@ -47,11 +53,13 @@ const TaskResource = {
     },
     {
       key: 'remind_at',
-      label: 'Alert'
+      label: 'Alert',
+      type: 'datetime',
     },
     {
       key: 'overdue',
-      label: 'Is overdue?'
+      label: 'Is overdue?',
+      type: 'boolean',
     }
   ]
 }

--- a/src/products/catalog/fields/productOutputFields.ts
+++ b/src/products/catalog/fields/productOutputFields.ts
@@ -3,35 +3,43 @@ import {OutputField} from '../../../types'
 export const productOutputFields: OutputField[] = [
   {
     key: 'id',
-    label: 'Product ID'
+    label: 'Product ID',
+    type: 'integer',
   },
   {
     key: 'name',
-    label: 'Name'
+    label: 'Name',
+    type: 'string',
   },
   {
     key: 'description',
-    label: 'Description'
+    label: 'Description',
+    type: 'string',
   },
   {
     key: 'sku',
-    label: 'SKU'
+    label: 'SKU',
+    type: 'string',
   },
   {
     key: 'max_discount',
-    label: 'Max Discount'
+    label: 'Max Discount',
+    type: 'number',
   },
   {
     key: 'max_markup',
-    label: 'Max markup'
+    label: 'Max markup',
+    type: 'number',
   },
   {
     key: 'cost',
-    label: 'Unit Cost'
+    label: 'Unit Cost',
+    type: 'string',
   },
   {
     key: 'cost_currency',
-    label: 'Unit Cost Currency'
+    label: 'Unit Cost Currency',
+    type: 'string',
   },
   {
     key: 'prices[]amount',

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface InputField {
  */
 export interface OutputField {
   key: string,
-  label: string
+  label: string,
+  type?: string
 }
 

--- a/src/utils/deduplication.ts
+++ b/src/utils/deduplication.ts
@@ -71,6 +71,18 @@ export const findAndRemapOnlyChangedItems = (
     .map(item => remapDeduplicationId(item, triggerFieldPath || modificationTimeField))
 }
 
+/**
+ * Remaps output fields from sample using deduplication ID.
+ * For triggers like UpdatedContact we are building DeduplicationId from Id and Updated_at fields.
+ */
+export const sampleWithDeduplicationId = (item: any) => {
+  return {
+    ...item,
+    entity_original_id: 100,
+    id: "100_2014-09-29T16:32:56Z"
+  }
+}
+
 export const findAndRemapOnlyUpdatedItems = (items: any[], triggerFieldPath?: string) =>
   findAndRemapOnlyChangedItems(items, 'updated_at', triggerFieldPath)
 

--- a/src/utils/deduplication.ts
+++ b/src/utils/deduplication.ts
@@ -79,7 +79,7 @@ export const sampleWithDeduplicationId = (item: any) => {
   return {
     ...item,
     entity_original_id: 100,
-    id: "100_2014-09-29T16:32:56Z"
+    id: '100_2014-09-29T16:32:56Z'
   }
 }
 


### PR DESCRIPTION
It generates false-positives and reacts upon lead creation - it should not. It's caused by building DeduplicationId from LeadId and Status.

This is very similar to this one: https://github.com/zendesk/zendesk-sell-for-zapier/pull/7