### PR TITLE
Implicit conversion betwen Person and Company fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.18
+
+* Fixing implicit conversion between Person and Company when for instance Person is passed to Update Company action
+
 ## 1.0.17
 
 * Fixing internal warnings related to output types

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zendesk-sell-for-zapier",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Zendesk Sell App in Zapier",
   "repository": "git@github.com:zendesk/zendesk-sell-for-zapier.git",
   "homepage": "https://www.zendesk.com/sell/",

--- a/src/contact/__test__/contact.action.test.ts
+++ b/src/contact/__test__/contact.action.test.ts
@@ -139,8 +139,7 @@ describe('update person action', () => {
       .put('/contacts/600', {
         data: {
           first_name: 'Uzi',
-          last_name: 'Shmilovici',
-          is_organization: false
+          last_name: 'Shmilovici'
         }
       })
       .reply(200, {data: {id: 600}})
@@ -174,8 +173,7 @@ describe('update company action', () => {
           name: 'Base CRM',
           address: {
             state: 'CA'
-          },
-          is_organization: true
+          }
         }
       })
       .reply(200, {data: {id: 100}})

--- a/src/contact/common.ts
+++ b/src/contact/common.ts
@@ -50,7 +50,7 @@ export const createContact = (type: ContactType, actionDetails: ActionDetails) =
   createEntity(contactsEndpoint, actionDetails, EntityType.Contact, appendOrganisation(type))
 
 export const updateContact = (type: ContactType, actionDetails: ActionDetails) =>
-  updateEntity(contactsEndpoint, actionDetails, EntityType.Contact, appendOrganisation(type))
+  updateEntity(contactsEndpoint, actionDetails, EntityType.Contact)
 
 export const createOrUpdateContact = (type: ContactType, actionDetails: ActionDetails) =>
   createOrUpdateEntity(contactsEndpoint, actionDetails, EntityType.Contact, appendOrganisation(type))


### PR DESCRIPTION
There is a single API endpoint for both Person and Company in Contacts and the only thing that differentiates those entities is the value of property `is_organization`. Public API allows to `convert` Person to Company (and back) by changing this attribute during update (PUT).
Zapier App has explicit update actions for Company and Person `UpdateCompany` and `UpdatePerson`, but user still may accidentally pass Person to UpdateCompany by using id explicitly. 

Having that said, current implementation adds `is_organization` to every request sent to Contacts API, but it's not necessary for update actions - removing it from PUTs will prevent from implicit conversion between Person and Company