### PR TITLE
Dynamic dropdowns - fixing pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.19
 
 * Added explanation to `Resource Id` field in Tasks and Notes 
+* Fixing pagination for dynamic dropdowns
 
 ## 1.0.18
 

--- a/src/common/__test__/queries.test.ts
+++ b/src/common/__test__/queries.test.ts
@@ -88,7 +88,7 @@ describe('searchByCriteria', () => {
 
 describe('fetchItems', () => {
   it('should unpack page & sort params properly', async () => {
-    const bundle = createFakeBundle({}, {page: 3})
+    const bundle = createFakeBundle({}, {page: 2})
     const z = createFakeZObject(200, {items: [{id: 10}]})
 
     const response = await fetchItems(endpoint, createFakeActionDetails())(z, bundle, {}, {

--- a/src/utils/__test__/api.test.ts
+++ b/src/utils/__test__/api.test.ts
@@ -1,4 +1,4 @@
-import {fetchResourceAsArray, hasIdDefined, SortOrder, sortParameter} from '../api'
+import {extractPageParameter, fetchResourceAsArray, hasIdDefined, SortOrder, sortParameter} from '../api'
 import {Bundle} from 'zapier-platform-core'
 import {createFakeBundle, createFakeZObject} from '../testHelpers'
 
@@ -67,5 +67,43 @@ describe('fetchResourceAsArray', () => {
     expect(items[0]).toHaveProperty('name', 'Uzi')
 
     expect(z.url()).toEqual('https://api.getbase.com/v2/resources/100')
+  })
+})
+
+describe('extractPageParameter', () => {
+  it('should return first page when 0 is present in meta', () => {
+    const bundle = createFakeBundle({id: 100}, {page: 0, limit: null})
+    const page = extractPageParameter(bundle)
+    expect(page).toEqual({
+      page: 1,
+      per_page: 100
+    })
+  })
+
+  it('should return first page when meta.page is not present', () => {
+    const bundle = createFakeBundle({id: 100}, {page: null, limit: null})
+    const page = extractPageParameter(bundle)
+    expect(page).toEqual({
+      page: 1,
+      per_page: 100
+    })
+  })
+
+  it('should return first page when 0 is present in meta and default is provided', () => {
+    const bundle = createFakeBundle({id: 100}, {page: 0, limit: null})
+    const page = extractPageParameter(bundle, 100)
+    expect(page).toEqual({
+      page: 1,
+      per_page: 100
+    })
+  })
+
+  it('should return proper API page', () => {
+    const bundle = createFakeBundle({id: 100}, {page: 2, limit: null})
+    const page = extractPageParameter(bundle)
+    expect(page).toEqual({
+      page: 3,
+      per_page: 100
+    })
   })
 })

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,4 +1,4 @@
-import {isEmpty, pick, pickBy} from 'lodash'
+import {isEmpty, pick, pickBy, isNumber} from 'lodash'
 import {Bundle, ZObject} from 'zapier-platform-core'
 import {fetch, isResourcePresentInResponse, unpackItemResponseAsArray, unpackSingleItemResponse} from './http'
 import {ActionDetails} from './operations'
@@ -65,8 +65,15 @@ export const sortParameter = (sort?: SortDefinition): ApiSortParameter => {
   }
 }
 
+const normalizedZapierPage = (bundle: Bundle, pageNumber?: number): number | undefined => {
+  if (bundle && bundle.meta && isNumber(bundle.meta.page)) {
+    return bundle.meta.page + 1 // Zapier starts indexing pages from 0
+  }
+  return pageNumber
+}
+
 export const extractPageParameter = (bundle: Bundle, pageNumber?: number, pageSize?: number) =>
-  pageParameter((bundle && bundle.meta && bundle.meta.page) || pageNumber, pageSize)
+  pageParameter(normalizedZapierPage(bundle, pageNumber), pageSize)
 
 export const pageParameter = (pageNumber: number = 1, pageSize: number = 100) => {
   return {

--- a/src/utils/testHelpers.ts
+++ b/src/utils/testHelpers.ts
@@ -19,7 +19,7 @@ export const createFakeBundle = (inputData: { [x: string]: any }, meta: object =
       isPopulatingDedupe: false,
       isTestingAuth: false,
       limit: 1,
-      page: 1,
+      page: 0,
       ...meta
     }
   }


### PR DESCRIPTION
Zapier start indexing pages from 0, but Sell Api from 1: https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#is-it-possible-to-iterate-over-pages-in-a-polling-trigger

Having said that, paging for dynamic dropdowns didn't work properly